### PR TITLE
Prevent calling count() on null object

### DIFF
--- a/src/FontAwesome.php
+++ b/src/FontAwesome.php
@@ -98,11 +98,11 @@ class FontAwesome extends FontAwesomeHtmlEntity
         $attrs   = '';
         $classes = 'fa-' . $this->icon;
 
-        if (count($this->classes) > 0) {
+        if (!empty($this->classes) && count($this->classes) > 0) {
             $classes .= ' ' . implode(' ', $this->classes);
         }
 
-        if (count($this->attributes) > 0) {
+        if (!empty($this->attributes) && count($this->attributes) > 0) {
             foreach ($this->attributes as $attr => $val) {
                 $attrs .= ' ' . $attr . '="' . $val . '"';
             }


### PR DESCRIPTION
Calling count on the null object is throwing errors like:
`PHP Fatal error:  Method Khill\FontAwesome\FontAwesome::__toString() must not throw an exception`

(On PHP 7.2 anyway)

Adding `!empty()` ensures it doesn't attempt to iterate over the null object.